### PR TITLE
Unload effect synchronous by default

### DIFF
--- a/ios/Classes/BanubaSdkPluginImpl.swift
+++ b/ios/Classes/BanubaSdkPluginImpl.swift
@@ -79,7 +79,7 @@ public class BanubaSdkPluginImpl: NSObject, BanubaSdkManager, VideoRecorderDeleg
     
     func unloadEffect() {
         Self.logger.debug("unloadEffect")
-        banubaSdkManager.loadEffect("")
+        banubaSdkManager.loadEffect("", synchronous: true)
     }
 
     func startPlayer() {


### PR DESCRIPTION
Вызов unloadEffect синхронно, так же как сейчас реализовано в андройд плагине - https://github.com/Banuba/banuba-sdk-flutter/blob/22ef4d55072f16d3ba2891bd56baf9f63946b5be/android/src/main/java/com/banuba/sdk/flutter/BanubaSdkPluginImpl.java#L263